### PR TITLE
Use standard java lib facilities to generate call identifiers

### DIFF
--- a/ocpp-json/src/main/scala/com/thenewmotion/ocpp/json/CallIdGenerator.scala
+++ b/ocpp-json/src/main/scala/com/thenewmotion/ocpp/json/CallIdGenerator.scala
@@ -10,7 +10,7 @@ object CallIdGenerator {
 }
 
 class AtomicCallIdGenerator extends CallIdGenerator {
-  private var id = new java.util.concurrent.atomic.AtomicLong(-1)
+  private val id = new java.util.concurrent.atomic.AtomicLong(-1)
 
   def next() = id.incrementAndGet.toHexString
 }


### PR DESCRIPTION
Usage of AtomicLong to store id makes things faster and removes the need for synchronized block. 

Rename to AtomicCallIdGenerator describes a bit better how it does the thing.
