### PR TITLE
Do not drag common library

### DIFF
--- a/ocpp-spray/pom.xml
+++ b/ocpp-spray/pom.xml
@@ -25,10 +25,6 @@
             <artifactId>spray-httpx_${scala.version}</artifactId>
         </dependency>
         <dependency>
-            <groupId>com.thenewmotion</groupId>
-            <artifactId>common_${scala.version}</artifactId>
-        </dependency>
-        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
         </dependency>

--- a/ocpp-spray/src/main/scala/com/thenewmotion/ocpp/spray/SoapPost.scala
+++ b/ocpp-spray/src/main/scala/com/thenewmotion/ocpp/spray/SoapPost.scala
@@ -1,22 +1,21 @@
 package com.thenewmotion.ocpp.spray
 
-import javax.xml.soap.SOAPConstants
-import spray.http.StatusCodes._
-
-import spray.http.{HttpHeader, HttpMethods, HttpRequest, StatusCode}
-import com.thenewmotion.http.{MediaProperty, MediaType}
+import javax.xml.soap.SOAPConstants.SOAP_1_2_CONTENT_TYPE
+import spray.http._, StatusCodes._, HttpHeaders.`Content-Type`
 
 /**
  * @author Yaroslav Klymko
  */
-
 object SoapPost {
-  def unapply(req: HttpRequest): Either[StatusCode, List[MediaProperty]] =
-    req.method -> MediaType(req.headers.collectFirst {
-      case x: HttpHeader if x is "content-type" => x.value
-    }.getOrElse("")) match {
-      case (HttpMethods.POST, MediaType(SOAPConstants.SOAP_1_2_CONTENT_TYPE, ps)) => Right(ps)
-      case (HttpMethods.POST, _) => Left(UnsupportedMediaType)
-      case _ => Left(MethodNotAllowed)
-    }
+  def unapply(req: HttpRequest): Either[StatusCode, HttpRequest] = req match {
+    case r@HttpRequest(HttpMethods.POST,_,hs,_,_) =>
+      hs.find(hasSoapMediaType).map(_ => r).toRight(UnsupportedMediaType)
+    case _ => Left(MethodNotAllowed)
+  }
+
+  private def hasSoapMediaType(h: HttpHeader) = PartialFunction.cond(h) {
+    case `Content-Type`(ContentType(mt, _)) =>
+      mt.mainType+'/'+mt.subType == SOAP_1_2_CONTENT_TYPE
+  }
+
 }

--- a/ocpp-spray/src/test/scala/com/thenewmotion/ocpp/spray/OcppProcessingSpec.scala
+++ b/ocpp-spray/src/test/scala/com/thenewmotion/ocpp/spray/OcppProcessingSpec.scala
@@ -44,7 +44,7 @@ class OcppProcessingSpec extends SpecificationWithJUnit with Mockito with SoapUt
 
       response.entity.asString must beMatching(".*Fault.*") and beMatching(".*b0rk! b0rk!.*")
     }
-    
+
     "produce a Fault response if the processing function throws" in new TestScope {
       val throwingProcessingFunction = mock[(ChargerInfo, CsReq) => Future[CsRes]]
       throwingProcessingFunction(any, any) throws new RuntimeException("b0rk! b0rk!")

--- a/pom.xml
+++ b/pom.xml
@@ -95,11 +95,6 @@
                 <version>${spray.version}</version>
             </dependency>
             <dependency>
-                <groupId>com.thenewmotion</groupId>
-                <artifactId>common_${scala.version}</artifactId>
-                <version>1.24</version>
-            </dependency>
-            <dependency>
                 <groupId>org.json4s</groupId>
                 <artifactId>json4s-native_${scala.version}</artifactId>
                 <version>${json4s.version}</version>


### PR DESCRIPTION
For vanishingly small purpose of finding out whether request is proper SOAP request we
added kitchen sink of 'utils' including obsolete dispatch library that then should be excluded
by any application using this library or common one.

This PR addresses this issue solely.
